### PR TITLE
Bug. Error code value 0xFF used as array index.

### DIFF
--- a/software/WLR089U0_P2P_v1.05/src/ASF/thirdparty/wireless/LoRa_P2P/source/mimac/phy/sx1276/phy.c
+++ b/software/WLR089U0_P2P_v1.05/src/ASF/thirdparty/wireless/LoRa_P2P/source/mimac/phy/sx1276/phy.c
@@ -294,8 +294,8 @@ void radioCallback(RadioCallbackID_t callback, void *param)
 					}
 				}
 					callbackRx = (RadioCallbackParam_t *)param;
-
-						
+				// Check if RxBank value is valid and not 'all buffer slots full' aka 0xFF
+				if (RxBank < BANK_SIZE) { //Keep indentation of code below, to minimize git check-in diff size 
 				RxBuffer[RxBank].PayloadLen = callbackRx->RX.bufferLength;
 				if (RxBuffer[RxBank].PayloadLen < (RX_PACKET_SIZE - 4))			
 				{
@@ -324,6 +324,7 @@ void radioCallback(RadioCallbackID_t callback, void *param)
 					RadioReceiveParam.rxWindowSize = 0;
 					RADIO_Receive(&RadioReceiveParam);	
 				}
+                                } //End of check for valid RxBank value
 		break;
 		case RADIO_RX_ERROR_CALLBACK:
 				RadioReceiveParam.action = RECEIVE_START;


### PR DESCRIPTION
When a packet is received and all Rx buffers are full, the variable RxBank is left with its pre-initialized value of 0xFF.
The RxBank variable was then used as an array index into a buffer array of BANK_SIZE elements. 
The error code value of uint8_t 0xFF used as an array index causes packet data to be written far outside the memory allocated
for the buffer table of BANK_SIZE elements (4 elements).

255 > 4

:-)

